### PR TITLE
Update example for diagnostic use and to give explicit example

### DIFF
--- a/ChomboTools/.clang-format
+++ b/ChomboTools/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+BreakBeforeInheritanceComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/ChomboTools/ReprocessFiles/CustomExtraction.hpp
+++ b/ChomboTools/ReprocessFiles/CustomExtraction.hpp
@@ -18,72 +18,79 @@
 
 //!  The class allows extraction of the values of components at
 //!  specified points
-class CustomExtraction {
-private:
-  //! Params for extraction
-  const int m_comp;
-  const int m_num_points;
-  const double m_L;
-  const std::array<double, CH_SPACEDIM> m_center;
-  const double m_dt;
-  const double m_time;
+class CustomExtraction
+{
+  private:
+    //! Params for extraction
+    const int m_comp;
+    const int m_num_points;
+    const double m_L;
+    const std::array<double, CH_SPACEDIM> m_center;
+    const double m_dt;
+    const double m_time;
 
-public:
-  //! The constructor
-  CustomExtraction(int a_comp, int a_num_points, double a_L,
-                   std::array<double, CH_SPACEDIM> a_center, double a_dt,
-                   double a_time)
-      : m_comp(a_comp), m_num_points(a_num_points), m_center(a_center),
-        m_L(a_L), m_dt(a_dt), m_time(a_time) {}
-
-  //! Destructor
-  ~CustomExtraction() {}
-
-  //! Execute the query
-  void execute_query(AMRInterpolator<Lagrange<4>> *a_interpolator,
-                     std::string a_file_prefix) const {
-    CH_TIME("CustomExtraction::execute_query");
-    if (a_interpolator == nullptr) {
-      MayDay::Error("Interpolator has not been initialised.");
-    }
-    std::vector<double> interp_var_data(m_num_points);
-    std::vector<double> interp_x(m_num_points);
-    std::vector<double> interp_y(m_num_points);
-    std::vector<double> interp_z(m_num_points);
-
-    // Work out the coordinates
-    // go out radially in diagonal dircetion to L/2
-    for (int idx = 0; idx < m_num_points; ++idx) {
-      interp_x[idx] =
-          m_center[0] + (double(idx) / double(m_num_points) * 0.5 * m_L);
-      interp_y[idx] =
-          m_center[1] + (double(idx) / double(m_num_points) * 0.5 * m_L);
-      interp_z[idx] =
-          m_center[2] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+  public:
+    //! The constructor
+    CustomExtraction(int a_comp, int a_num_points, double a_L,
+                     std::array<double, CH_SPACEDIM> a_center, double a_dt,
+                     double a_time)
+        : m_comp(a_comp), m_num_points(a_num_points), m_center(a_center),
+          m_L(a_L), m_dt(a_dt), m_time(a_time)
+    {
     }
 
-    // set up the query
-    InterpolationQuery query(m_num_points);
-    query.setCoords(0, interp_x.data())
-        .setCoords(1, interp_y.data())
-        .setCoords(2, interp_z.data())
-        .addComp(m_comp, interp_var_data.data(), Derivative::LOCAL,
-                 VariableType::evolution);
+    //! Destructor
+    ~CustomExtraction() {}
 
-    // submit the query
-    a_interpolator->interp(query);
+    //! Execute the query
+    void execute_query(AMRInterpolator<Lagrange<4>> *a_interpolator,
+                       std::string a_file_prefix) const
+    {
+        CH_TIME("CustomExtraction::execute_query");
+        if (a_interpolator == nullptr)
+        {
+            MayDay::Error("Interpolator has not been initialised.");
+        }
+        std::vector<double> interp_var_data(m_num_points);
+        std::vector<double> interp_x(m_num_points);
+        std::vector<double> interp_y(m_num_points);
+        std::vector<double> interp_z(m_num_points);
 
-    // now write out
-    bool first_step = (m_time == 0.0);
-    double restart_time = 0.0;
-    SmallDataIO output_file(a_file_prefix, m_dt, m_time, restart_time,
-                            SmallDataIO::APPEND, first_step);
+        // Work out the coordinates
+        // go out radially in diagonal dircetion to L/2
+        for (int idx = 0; idx < m_num_points; ++idx)
+        {
+            interp_x[idx] =
+                m_center[0] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+            interp_y[idx] =
+                m_center[1] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+            interp_z[idx] =
+                m_center[2] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+        }
 
-    if (first_step) {
-      output_file.write_header_line({"r values"});
+        // set up the query
+        InterpolationQuery query(m_num_points);
+        query.setCoords(0, interp_x.data())
+            .setCoords(1, interp_y.data())
+            .setCoords(2, interp_z.data())
+            .addComp(m_comp, interp_var_data.data(), Derivative::LOCAL,
+                     VariableType::evolution);
+
+        // submit the query
+        a_interpolator->interp(query);
+
+        // now write out
+        bool first_step = (m_time == 0.0);
+        double restart_time = 0.0;
+        SmallDataIO output_file(a_file_prefix, m_dt, m_time, restart_time,
+                                SmallDataIO::APPEND, first_step);
+
+        if (first_step)
+        {
+            output_file.write_header_line({"r values"});
+        }
+        output_file.write_time_data_line(interp_var_data);
     }
-    output_file.write_time_data_line(interp_var_data);
-  }
 };
 
 #endif /* CUSTOMEXTRACTION_HPP_ */

--- a/ChomboTools/ReprocessFiles/CustomExtraction.hpp
+++ b/ChomboTools/ReprocessFiles/CustomExtraction.hpp
@@ -1,0 +1,89 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef CUSTOMEXTRACTION_HPP_
+#define CUSTOMEXTRACTION_HPP_
+
+#include "AMRInterpolator.hpp"
+#include "InterpolationQuery.hpp"
+#include "Lagrange.hpp"
+#include "SimulationParametersBase.hpp"
+#include "SmallDataIO.hpp"
+#include "SphericalHarmonics.hpp"
+#include "UserVariables.hpp"
+#include <fstream>
+#include <iostream>
+
+//!  The class allows extraction of the values of components at
+//!  specified points
+class CustomExtraction {
+private:
+  //! Params for extraction
+  const int m_comp;
+  const int m_num_points;
+  const double m_L;
+  const std::array<double, CH_SPACEDIM> m_center;
+  const double m_dt;
+  const double m_time;
+
+public:
+  //! The constructor
+  CustomExtraction(int a_comp, int a_num_points, double a_L,
+                   std::array<double, CH_SPACEDIM> a_center, double a_dt,
+                   double a_time)
+      : m_comp(a_comp), m_num_points(a_num_points), m_center(a_center),
+        m_L(a_L), m_dt(a_dt), m_time(a_time) {}
+
+  //! Destructor
+  ~CustomExtraction() {}
+
+  //! Execute the query
+  void execute_query(AMRInterpolator<Lagrange<4>> *a_interpolator,
+                     std::string a_file_prefix) const {
+    CH_TIME("CustomExtraction::execute_query");
+    if (a_interpolator == nullptr) {
+      MayDay::Error("Interpolator has not been initialised.");
+    }
+    std::vector<double> interp_var_data(m_num_points);
+    std::vector<double> interp_x(m_num_points);
+    std::vector<double> interp_y(m_num_points);
+    std::vector<double> interp_z(m_num_points);
+
+    // Work out the coordinates
+    // go out radially in diagonal dircetion to L/2
+    for (int idx = 0; idx < m_num_points; ++idx) {
+      interp_x[idx] =
+          m_center[0] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+      interp_y[idx] =
+          m_center[1] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+      interp_z[idx] =
+          m_center[2] + (double(idx) / double(m_num_points) * 0.5 * m_L);
+    }
+
+    // set up the query
+    InterpolationQuery query(m_num_points);
+    query.setCoords(0, interp_x.data())
+        .setCoords(1, interp_y.data())
+        .setCoords(2, interp_z.data())
+        .addComp(m_comp, interp_var_data.data(), Derivative::LOCAL,
+                 VariableType::evolution);
+
+    // submit the query
+    a_interpolator->interp(query);
+
+    // now write out
+    bool first_step = (m_time == 0.0);
+    double restart_time = 0.0;
+    SmallDataIO output_file(a_file_prefix, m_dt, m_time, restart_time,
+                            SmallDataIO::APPEND, first_step);
+
+    if (first_step) {
+      output_file.write_header_line({"r values"});
+    }
+    output_file.write_time_data_line(interp_var_data);
+  }
+};
+
+#endif /* CUSTOMEXTRACTION_HPP_ */

--- a/ChomboTools/ReprocessFiles/ReprocessingLevel.hpp
+++ b/ChomboTools/ReprocessFiles/ReprocessingLevel.hpp
@@ -6,33 +6,50 @@
 #ifndef REPROCESSINGLEVEL_HPP_
 #define REPROCESSINGLEVEL_HPP_
 
+#include "CustomExtraction.hpp"
 #include "GRAMRLevel.hpp"
 
-class ReprocessingLevel : public GRAMRLevel
-{
-    friend class DefaultLevelFactory<ReprocessingLevel>;
-    // Inherit the contructors from GRAMRLevel
-    using GRAMRLevel::GRAMRLevel;
+class ReprocessingLevel : public GRAMRLevel {
+  friend class DefaultLevelFactory<ReprocessingLevel>;
+  // Inherit the contructors from GRAMRLevel
+  using GRAMRLevel::GRAMRLevel;
 
-    // initialize data
-    virtual void initialData() { m_state_new.setVal(0.); }
+  // initialize data
+  virtual void initialData() { m_state_new.setVal(0.); }
 
-    void postRestart()
-    {
-        // Add code here to do what you need it to do on each level
-        // Note that if you want the AMRInterpolator you need to define it
-        // and set it here (currently it is just a nullptr)
-        pout() << "The time is " << m_time << " on level " << m_level 
-               << ". Your wish is my command." << endl;
+  void postRestart() {
+    // Add code here to do what you need it to do on each level
+    // Note that if you want the AMRInterpolator you need to define it
+    // and set it here (currently it is just a nullptr)
+    pout() << "The time is " << m_time << " on level " << m_level
+           << ". Your wish is my command." << endl;
+
+    // as an example, on the coarsest level do a simple extraction
+    // (NB will still take data from finest level which covers the points)
+    if (m_level == 0) {
+      // set up an interpolator
+      // pass the boundary params so that we can use symmetries if
+      // applicable
+      AMRInterpolator<Lagrange<4>> interpolator(
+          m_gr_amr, m_p.origin, m_p.dx, m_p.boundary_params, m_p.verbosity);
+
+      // this should fill all ghosts including the boundary ones according
+      // to the conditions set in params.txt
+      interpolator.refresh();
+
+      // set up the query and execute it
+      int num_points = 4;
+      CustomExtraction extraction(c_chi, num_points, m_p.L, m_p.center, m_dt,
+                                  m_time);
+      extraction.execute_query(&interpolator, "outputs");
     }
+  }
 
-    virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
-                                 const double a_time)
-    {
-    }
+  virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
+                               const double a_time) {}
 
-    virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                         const FArrayBox &current_state){};
+  virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
+                                       const FArrayBox &current_state){};
 };
 
 #endif /* REPROCESSINGLEVEL_HPP_ */

--- a/ChomboTools/ReprocessFiles/ReprocessingLevel.hpp
+++ b/ChomboTools/ReprocessFiles/ReprocessingLevel.hpp
@@ -9,47 +9,53 @@
 #include "CustomExtraction.hpp"
 #include "GRAMRLevel.hpp"
 
-class ReprocessingLevel : public GRAMRLevel {
-  friend class DefaultLevelFactory<ReprocessingLevel>;
-  // Inherit the contructors from GRAMRLevel
-  using GRAMRLevel::GRAMRLevel;
+class ReprocessingLevel : public GRAMRLevel
+{
+    friend class DefaultLevelFactory<ReprocessingLevel>;
+    // Inherit the contructors from GRAMRLevel
+    using GRAMRLevel::GRAMRLevel;
 
-  // initialize data
-  virtual void initialData() { m_state_new.setVal(0.); }
+    // initialize data
+    virtual void initialData() { m_state_new.setVal(0.); }
 
-  void postRestart() {
-    // Add code here to do what you need it to do on each level
-    // Note that if you want the AMRInterpolator you need to define it
-    // and set it here (currently it is just a nullptr)
-    pout() << "The time is " << m_time << " on level " << m_level
-           << ". Your wish is my command." << endl;
+    void postRestart()
+    {
+        // Add code here to do what you need it to do on each level
+        // Note that if you want the AMRInterpolator you need to define it
+        // and set it here (currently it is just a nullptr)
+        pout() << "The time is " << m_time << " on level " << m_level
+               << ". Your wish is my command." << endl;
 
-    // as an example, on the coarsest level do a simple extraction
-    // (NB will still take data from finest level which covers the points)
-    if (m_level == 0) {
-      // set up an interpolator
-      // pass the boundary params so that we can use symmetries if
-      // applicable
-      AMRInterpolator<Lagrange<4>> interpolator(
-          m_gr_amr, m_p.origin, m_p.dx, m_p.boundary_params, m_p.verbosity);
+        // as an example, on the coarsest level do a simple extraction
+        // (NB will still take data from finest level which covers the points)
+        if (m_level == 0)
+        {
+            // set up an interpolator
+            // pass the boundary params so that we can use symmetries if
+            // applicable
+            AMRInterpolator<Lagrange<4>> interpolator(
+                m_gr_amr, m_p.origin, m_p.dx, m_p.boundary_params,
+                m_p.verbosity);
 
-      // this should fill all ghosts including the boundary ones according
-      // to the conditions set in params.txt
-      interpolator.refresh();
+            // this should fill all ghosts including the boundary ones according
+            // to the conditions set in params.txt
+            interpolator.refresh();
 
-      // set up the query and execute it
-      int num_points = 4;
-      CustomExtraction extraction(c_chi, num_points, m_p.L, m_p.center, m_dt,
-                                  m_time);
-      extraction.execute_query(&interpolator, "outputs");
+            // set up the query and execute it
+            int num_points = 4;
+            CustomExtraction extraction(c_chi, num_points, m_p.L, m_p.center,
+                                        m_dt, m_time);
+            extraction.execute_query(&interpolator, "outputs");
+        }
     }
-  }
 
-  virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
-                               const double a_time) {}
+    virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
+                                 const double a_time)
+    {
+    }
 
-  virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                       const FArrayBox &current_state){};
+    virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
+                                         const FArrayBox &current_state){};
 };
 
 #endif /* REPROCESSINGLEVEL_HPP_ */

--- a/ChomboTools/ReprocessFiles/ReprocessingTool.cpp
+++ b/ChomboTools/ReprocessFiles/ReprocessingTool.cpp
@@ -38,44 +38,47 @@ using std::endl;
 #include <omp.h>
 #endif
 
-int runReprocessingTool(int argc, char *argv[]) {
-  // Load the parameter file and construct the SimulationParameter class
-  // To add more parameters edit the SimulationParameters file.
-  std::string in_string = argv[argc - 1];
-  pout() << in_string << std::endl;
-  char const *in_file = argv[argc - 1];
-  GRParmParse pp(0, argv + argc, NULL, in_file);
-  SimulationParameters sim_params(pp);
+int runReprocessingTool(int argc, char *argv[])
+{
+    // Load the parameter file and construct the SimulationParameter class
+    // To add more parameters edit the SimulationParameters file.
+    std::string in_string = argv[argc - 1];
+    pout() << in_string << std::endl;
+    char const *in_file = argv[argc - 1];
+    GRParmParse pp(0, argv + argc, NULL, in_file);
+    SimulationParameters sim_params(pp);
 
-  // Setup the initial object (from restart_file checkpoint)
-  GRAMR gr_amr;
-  DefaultLevelFactory<ReprocessingLevel> empty_level_fact(gr_amr, sim_params);
-  setupAMRObject(gr_amr, empty_level_fact);
+    // Setup the initial object (from restart_file checkpoint)
+    GRAMR gr_amr;
+    DefaultLevelFactory<ReprocessingLevel> empty_level_fact(gr_amr, sim_params);
+    setupAMRObject(gr_amr, empty_level_fact);
 
-  // now loop over chk files
-  for (int ifile = sim_params.start_file; ifile < sim_params.num_files;
-       ifile++) {
-    // set up the file from next checkpoint
-    std::ostringstream current_file;
-    current_file << std::setw(6) << std::setfill('0')
-                 << ifile * sim_params.checkpoint_interval;
-    std::string restart_file(sim_params.checkpoint_prefix + current_file.str() +
-                             ".3d.hdf5");
-    HDF5Handle handle(restart_file, HDF5Handle::OPEN_RDONLY);
-    gr_amr.setupForRestart(handle);
-    handle.close();
-  }
+    // now loop over chk files
+    for (int ifile = sim_params.start_file; ifile < sim_params.num_files;
+         ifile++)
+    {
+        // set up the file from next checkpoint
+        std::ostringstream current_file;
+        current_file << std::setw(6) << std::setfill('0')
+                     << ifile * sim_params.checkpoint_interval;
+        std::string restart_file(sim_params.checkpoint_prefix +
+                                 current_file.str() + ".3d.hdf5");
+        HDF5Handle handle(restart_file, HDF5Handle::OPEN_RDONLY);
+        gr_amr.setupForRestart(handle);
+        handle.close();
+    }
 
-  gr_amr.conclude();
+    gr_amr.conclude();
 
-  return 0;
+    return 0;
 }
 
-int main(int argc, char *argv[]) {
-  mainSetup(argc, argv);
+int main(int argc, char *argv[])
+{
+    mainSetup(argc, argv);
 
-  int status = runReprocessingTool(argc, argv);
+    int status = runReprocessingTool(argc, argv);
 
-  mainFinalize();
-  return status;
+    mainFinalize();
+    return status;
 }

--- a/ChomboTools/ReprocessFiles/ReprocessingTool.cpp
+++ b/ChomboTools/ReprocessFiles/ReprocessingTool.cpp
@@ -14,22 +14,22 @@
 #endif
 
 // General includes:
+#include "parstream.H" //Gives us pout()
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sys/time.h>
-#include "parstream.H" //Gives us pout()
 using std::endl;
 
 // Problem specific includes:
 #include "AMRInterpolator.hpp"
 #include "DefaultLevelFactory.hpp"
 #include "GRAMR.hpp"
-#include "ReprocessingLevel.hpp"
 #include "InterpolationQuery.hpp"
 #include "Lagrange.hpp"
+#include "ReprocessingLevel.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
 #include "UserVariables.hpp"
@@ -38,47 +38,44 @@ using std::endl;
 #include <omp.h>
 #endif
 
-int runReprocessingTool(int argc, char *argv[])
-{
-    // Load the parameter file and construct the SimulationParameter class
-    // To add more parameters edit the SimulationParameters file.
-    std::string in_string = argv[argc - 1];
-    pout() << in_string << std::endl;
-    char const *in_file = argv[argc - 1];
-    GRParmParse pp(0, argv + argc, NULL, in_file);
-    SimulationParameters sim_params(pp);
+int runReprocessingTool(int argc, char *argv[]) {
+  // Load the parameter file and construct the SimulationParameter class
+  // To add more parameters edit the SimulationParameters file.
+  std::string in_string = argv[argc - 1];
+  pout() << in_string << std::endl;
+  char const *in_file = argv[argc - 1];
+  GRParmParse pp(0, argv + argc, NULL, in_file);
+  SimulationParameters sim_params(pp);
 
-    // Setup the initial object (from restart_file checkpoint)
-    GRAMR gr_amr;
-    DefaultLevelFactory<ReprocessingLevel> empty_level_fact(gr_amr, sim_params);
-    setupAMRObject(gr_amr, empty_level_fact);
+  // Setup the initial object (from restart_file checkpoint)
+  GRAMR gr_amr;
+  DefaultLevelFactory<ReprocessingLevel> empty_level_fact(gr_amr, sim_params);
+  setupAMRObject(gr_amr, empty_level_fact);
 
-    // now loop over chk files
-    for (int ifile = sim_params.start_file; ifile < sim_params.num_files;
-         ifile++)
-    {
-        // set up the file from next checkpoint
-        std::ostringstream current_file;
-        current_file << std::setw(6) << std::setfill('0')
-                     << ifile * sim_params.checkpoint_interval;
-        std::string restart_file(sim_params.checkpoint_prefix + current_file.str() +
-                                 ".3d.hdf5");
-        HDF5Handle handle(restart_file, HDF5Handle::OPEN_RDONLY);
-        gr_amr.setupForRestart(handle);
-        handle.close();
-    }
+  // now loop over chk files
+  for (int ifile = sim_params.start_file; ifile < sim_params.num_files;
+       ifile++) {
+    // set up the file from next checkpoint
+    std::ostringstream current_file;
+    current_file << std::setw(6) << std::setfill('0')
+                 << ifile * sim_params.checkpoint_interval;
+    std::string restart_file(sim_params.checkpoint_prefix + current_file.str() +
+                             ".3d.hdf5");
+    HDF5Handle handle(restart_file, HDF5Handle::OPEN_RDONLY);
+    gr_amr.setupForRestart(handle);
+    handle.close();
+  }
 
-    gr_amr.conclude();
+  gr_amr.conclude();
 
-    return 0;
+  return 0;
 }
 
-int main(int argc, char *argv[])
-{
-    mainSetup(argc, argv);
+int main(int argc, char *argv[]) {
+  mainSetup(argc, argv);
 
-    int status = runReprocessingTool(argc, argv);
+  int status = runReprocessingTool(argc, argv);
 
-    mainFinalize();
-    return status;
+  mainFinalize();
+  return status;
 }

--- a/ChomboTools/ReprocessFiles/SimulationParameters.hpp
+++ b/ChomboTools/ReprocessFiles/SimulationParameters.hpp
@@ -10,22 +10,25 @@
 #include "ChomboParameters.hpp"
 #include "GRParmParse.hpp"
 
-class SimulationParameters : public ChomboParameters {
-public:
-  // For the Interpolator test we don't need many parameters
-  SimulationParameters(GRParmParse &pp) : ChomboParameters(pp) {
-    // read the problem specific params
-    readParams(pp);
-  }
+class SimulationParameters : public ChomboParameters
+{
+  public:
+    // For the Interpolator test we don't need many parameters
+    SimulationParameters(GRParmParse &pp) : ChomboParameters(pp)
+    {
+        // read the problem specific params
+        readParams(pp);
+    }
 
-  void readParams(GRParmParse &pp) {
-    // Grid setup
-    pp.get("num_files", num_files);
-    pp.get("start_file", start_file);
-    pp.get("checkpoint_interval", checkpoint_interval);
-  }
+    void readParams(GRParmParse &pp)
+    {
+        // Grid setup
+        pp.get("num_files", num_files);
+        pp.get("start_file", start_file);
+        pp.get("checkpoint_interval", checkpoint_interval);
+    }
 
-  int num_files, start_file, checkpoint_interval;
+    int num_files, start_file, checkpoint_interval;
 };
 
 #endif /* SIMULATIONPARAMETERS_HPP_ */

--- a/ChomboTools/ReprocessFiles/SimulationParameters.hpp
+++ b/ChomboTools/ReprocessFiles/SimulationParameters.hpp
@@ -7,34 +7,25 @@
 #define SIMULATIONPARAMETERS_HPP_
 
 // General includes
-#include "GRParmParse.hpp"
 #include "ChomboParameters.hpp"
+#include "GRParmParse.hpp"
 
-class SimulationParameters : public ChomboParameters
-{
-  public:
-    // For the Interpolator test we don't need many parameters
-    SimulationParameters(GRParmParse &pp) : ChomboParameters(pp)
-    {
-        // read the problem specific params
-        readParams(pp);
-    }
+class SimulationParameters : public ChomboParameters {
+public:
+  // For the Interpolator test we don't need many parameters
+  SimulationParameters(GRParmParse &pp) : ChomboParameters(pp) {
+    // read the problem specific params
+    readParams(pp);
+  }
 
-    void readParams(GRParmParse &pp)
-    {
-        // Grid setup
-        pp.get("num_files", num_files);
-        pp.get("start_file", start_file);
-        pp.get("checkpoint_interval", checkpoint_interval);
+  void readParams(GRParmParse &pp) {
+    // Grid setup
+    pp.get("num_files", num_files);
+    pp.get("start_file", start_file);
+    pp.get("checkpoint_interval", checkpoint_interval);
+  }
 
-        // extraction params
-        dx.fill(coarsest_dx);
-        origin.fill(coarsest_dx / 2.0);
-    }
-
-    int num_files, start_file, checkpoint_interval;
-    std::array<double, CH_SPACEDIM> origin,
-        dx; // location of coarsest origin and dx
+  int num_files, start_file, checkpoint_interval;
 };
 
 #endif /* SIMULATIONPARAMETERS_HPP_ */

--- a/ChomboTools/ReprocessFiles/UserVariables.hpp
+++ b/ChomboTools/ReprocessFiles/UserVariables.hpp
@@ -15,9 +15,15 @@
 // in which you added them to the plot files, so this may not match your ACTUAL
 // UserVariables.hpp file. For the purposes of this tool, all vars are treated
 // as evolution ones since we use the checkpoint restart feature
-enum { c_chi, c_rho, NUM_VARS };
+enum
+{
+    c_chi,
+    c_rho,
+    NUM_VARS
+};
 
-namespace UserVariables {
+namespace UserVariables
+{
 static const std::array<std::string, NUM_VARS> variable_names = {"chi", "rho"};
 }
 

--- a/ChomboTools/ReprocessFiles/UserVariables.hpp
+++ b/ChomboTools/ReprocessFiles/UserVariables.hpp
@@ -6,79 +6,21 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include "EmptyDiagnosticVariables.hpp"
+#include <array>
+#include <string>
+
 // assign an enum to each variable
-enum
-{
-    c_chi,
+// if restarting from plot files you should put the plot vars here in the order
+// in which you added them to the plot files, so this may not match your ACTUAL
+// UserVariables.hpp file. For the purposes of this tool, all vars are treated
+// as evolution ones since we use the checkpoint restart feature
+enum { c_chi, c_rho, NUM_VARS };
 
-    c_h11,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A11,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma1,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift1,
-    c_shift2,
-    c_shift3,
-
-    c_B1,
-    c_B2,
-    c_B3,
-
-    c_phi, // matter field added
-    c_Pi,  //(minus) conjugate momentum
-
-    c_Ham,
-
-    c_Mom1,
-    c_Mom2,
-    c_Mom3,
-
-    NUM_VARS
-};
-
-namespace UserVariables
-{
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
-
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
-
-    "K",
-
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "phi",    "Pi",
-
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
+namespace UserVariables {
+static const std::array<std::string, NUM_VARS> variable_names = {"chi", "rho"};
 }
+
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/ChomboTools/ReprocessFiles/params.txt
+++ b/ChomboTools/ReprocessFiles/params.txt
@@ -1,26 +1,37 @@
 #Params for runtime inputs
-N1 = 32
-N2 = 32
+N1 = 64
+N2 = 64
 N3 = 32
-L = 64
-max_level = 2 # There are (max_level+1) grids, so min is zero
+L = 512
+max_level = 4 # There are (max_level+1) grids, so min is zero
+verbosity = 0
 
 # For read in of files
-chk_prefix = ScalarField_
-restart_file = ScalarField_000000.3d.hdf5
+# note that this may actually be your plot_prefix if you are reprocessing plot files
+# (we want to trick Chombo into thinking these are checkpoints for restart)
+chk_prefix = BinaryBH_plt
+# ditto for the restart file - could actually be a plot file
+restart_file = BinaryBH_plt000000.3d.hdf5
+# what is the interval in the files you want to reprocess, and how many?
 checkpoint_interval = 1
 start_file = 0
-num_files = 3
+num_files = 5
 
 # For desired outputs, set plot interval to zero to turn off plot outputs
 plot_interval = 0
 plot_prefix = PlotFile
-base_dx = 0.0 # where to put zeroth point
-num_points = 5 # number of points in radial direction to extract
 
-# From here it is mostly dummy params
-verbosity = 0
+# Some dummy params to keep Chombo happy
 regrid_interval = 0 0 0 0 0
 max_grid_size = 16
-block_factor = 8
-isPeriodic = 1 1 1
+block_factor = 16
+
+# Boundary conditions - need to be adjusted to reflect those of original simulation
+# but note that you may want to set extrapolating conditions (3) for directions
+# where you did not write ghosts (e.g. sommerfeld boundaries in plot files) 
+# this will ensure they are filled with sensible values and not nans
+isPeriodic = 0 0 0
+hi_boundary = 3 3 3
+lo_boundary = 3 3 2
+vars_parity = 0 0 0 0 0 0 0 0 # one for each var in the UserVariables file
+extrapolation_order = 1

--- a/ChomboTools/run_clang_format
+++ b/ChomboTools/run_clang_format
@@ -1,0 +1,2 @@
+for f in $(find . -name "*.hpp"); do clang-format -style=file -i $f; done
+for f in $(find . -name "*.cpp"); do clang-format -style=file -i $f; done


### PR DESCRIPTION
I updated to fix for diagnostic vars. 

I also amended the example to make it more aligned with how it is used in practice - ie for reprocessing plot files rather than actual full checkpoint files. The use of extrapolating BCs allows you to use these even without the ghost cells having been written in sommerfeld directions. The example now also uses the boundary conditions so one can load symmetric cases.

I also added clang format.